### PR TITLE
Atualizando Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,23 +2,21 @@ FROM python:3.9-slim-bullseye
 
 LABEL app="livedivulgador"
 
-ADD . ./app
-
-RUN apt-get update \
-    && apt-get -yy install --no-install-recommends gcc libmariadb-dev \
-    && pip3 install -r ./app/requirements.txt \
-    && apt-get -y remove --purge --auto-remove gcc \
-    && apt-get -y autoremove \
-    && apt-get -y autoclean \
-    && apt-get -y clean \
-    && rm -rf /tmp/* \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /var/cache/apt/archives/* \
-
-    && pip cache purge \
-    && rm -rf /root/.cache/*
-
 WORKDIR /app
 
-# CMD [ "python3", "./app/src/bot/main.py" ]
+ADD . .
 
+RUN apt update \
+    && apt-get -yy install --no-install-recommends gcc libmariadb-dev \
+    && pip3 install -r ./requirements.txt \
+    && apt -y remove --purge --auto-remove gcc \
+    && apt -y autoremove \
+    && apt -y autoclean \
+    && apt -y clean \
+    && rm -rf /tmp/ \
+    && rm -rf /var/lib/apt/lists/ \
+    && rm -rf /var/cache/apt/archives/ \
+    && pip cache purge \
+    && rm -rf /root/.cache/
+
+# CMD [ "python3", "./app/src/bot/main.py" ]


### PR DESCRIPTION
## O que foi feito?
Foi alterada a ordem dos comandos do Docker, colocando o `WORKDIR` acima dos comandos executados pela maquina, definindo a area de trabalho da aplicação, e evitando ir até a pasta raiz do projeto, incluindo a pasta da aplicação desejada para executar um comando. Outra alteração foi na execução dos comandos, usado o gerenciador de pacotes da imagem, mudando de `apt-get`, para somente `apt` que é a forma mais recente e enxuta de usar o comando, visto que está sendo usado uma imagem Debian mais recente, na sua versão 11(bullseye), outras pequenas mudaças foi a remoção do `*` no final das pastas que estava sendo usado, mas sem a necessidade, porque a flag `-r` do comando `rm` já executa a ação de forma recursiva.